### PR TITLE
Tighten vertical space on introduction.

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -537,7 +537,7 @@
     </div>
 </div>
 
-<div class="content-list" id="video-and-articles">
+<div class="content-list grid-list" id="video-and-articles">
     <div class="row">
         <div class="col-xs-12 content-list-item-hed">
             <h3 class="name-head">Special report<span class="slug-link">&ensp;<a href="#video-and-articles"><i class="fa fa-link"></i></a></span></h3>
@@ -570,7 +570,7 @@
     </div>
 </div>
 
-<div class="content-list" id="meet-the-people">
+<div class="content-list grid-list" id="meet-the-people">
     <div class="row">
         <div class="col-xs-12 content-list-item-hed">
             <h3 class="name-head">Meet the people<span class="slug-link">&ensp;<a href="#meet-the-people"><i class="fa fa-link"></i></a></span></h3>

--- a/src/css/content-list.less
+++ b/src/css/content-list.less
@@ -33,3 +33,8 @@
         opacity: 1;
     }
 }
+
+.content-list.grid-list {
+    /* hack to reduce vertical space under grids */
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
For #47
The vertical spacing issue was most glaring on headlines placed below content grids because grid items add padding and float away from the left margin. This PR targets grids and reduces their bottom margins.