### PR TITLE
adding live coverage box to the home page

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -551,6 +551,13 @@
     <div id="main" class="col-xs-12">
         <h3 class="top-readout">On Aug. 1, 1966, engineering student Charles Whitman ascended the University of Texas Tower with a trunk full of guns and showed America how one ruthless person can inflict fear and grief on an entire city.</h3>
         <h3 class="top-readout">Even 50 years after Whitman’s sniper attack, ripple effects reach into Austin's present &mdash; from anxiety over the new campus carry law to changes in modern police response to mass shootings.</h3>
+        <div class="panel panel-default" id="live">
+          <div class="panel-body">
+            <h3>Live coverage on the Aug. 1st anniversary</h3>
+            <p>Check <a href="http://www.statesman.com" target="_blank">Statesman.com</a> on Monday for live coverage, including a video feed of the 11:30 a.m. memorial ceremony scheduled to take place on the UT campus.</p>
+          </div>
+        </div>
+
     </div>
   </div>
 

--- a/src/css/intro.less
+++ b/src/css/intro.less
@@ -94,10 +94,10 @@ div.topmain-wrapper {
 }
 
 h3.top-readout {
-    margin: 70px auto 70px auto;
+    margin: 50px auto 50px auto;
     font-size: 28px;
     &:nth-of-type(2) {
-        margin:-30px auto 70px auto;
+        margin:-30px auto 60px auto;
     }
 }
 

--- a/src/css/panels.less
+++ b/src/css/panels.less
@@ -22,3 +22,14 @@
     }
   }
 }
+
+#live {
+  margin-top: 50px;
+  background-color: #eee;
+  h3 {
+    margin-top: 13px;
+  }
+  p {
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
This pull request deals with adding a live coverage box to the home page of the tower package.

I'm using a standard bootstrap panel with some CSS additions to handle font size and some spacing.

On Monday, we'll want to update this to include links to the actual coverage. Once it is done, perhaps we can add a story card that has the links